### PR TITLE
feat(feedstock): add FinOwl summaries client with concurrent fetching  and tests

### DIFF
--- a/finowl-ai-assistant/.env.example
+++ b/finowl-ai-assistant/.env.example
@@ -12,3 +12,8 @@ NEAR_RPC_URL=https://rpc.testnet.near.org
 
 # Server
 PORT=8080
+
+# Finowl API Configuration
+FINOWL_API_BASE_URL=
+FINOWL_SUMMARY_PATH=
+FINOWL_HTTP_TIMEOUT=

--- a/finowl-ai-assistant/feedstock/client.go
+++ b/finowl-ai-assistant/feedstock/client.go
@@ -1,0 +1,138 @@
+package feedstock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Client handles interactions with the Finowl API
+type Client struct {
+	httpClient *http.Client
+	config     *Config
+}
+
+// NewClient creates a new Finowl API client
+func NewClient(baseURL string) *Client {
+	config := &Config{
+		APIBaseURL:   baseURL,
+		SummaryPath:  "/summary",
+		HTTPTimeout:  60 * time.Second,
+		DefaultValue: 0,
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: config.HTTPTimeout,
+		},
+		config: config,
+	}
+}
+
+// NewDefaultClient creates a new Finowl API client with configuration from environment
+func NewDefaultClient() *Client {
+	config := LoadConfig()
+
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: config.HTTPTimeout,
+		},
+		config: config,
+	}
+}
+
+// GetSummary fetches a summary by ID
+func (c *Client) GetSummary(id int) (*Summary, error) {
+	url := fmt.Sprintf("%s%s?id=%d", c.config.APIBaseURL, c.config.SummaryPath, id)
+
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("summary with ID %d not found", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var apiResponse Response
+	if err := json.NewDecoder(resp.Body).Decode(&apiResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &apiResponse.Summary, nil
+}
+
+// FetchSummaries fetches multiple summaries concurrently
+func (c *Client) FetchSummaries(startID, count int) ([]Summary, error) {
+	var wg sync.WaitGroup
+	summaries := make([]Summary, 0, count)
+	errors := make(chan error, count)
+	resultChan := make(chan Summary, count)
+
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			summary, err := c.GetSummary(id)
+			if err != nil {
+				errors <- fmt.Errorf("error fetching summary %d: %w", id, err)
+				return
+			}
+			resultChan <- *summary
+		}(startID - i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+		close(errors)
+	}()
+
+	for summary := range resultChan {
+		summaries = append(summaries, summary)
+	}
+
+	if len(errors) > 0 {
+		var errorStrings []string
+		for err := range errors {
+			errorStrings = append(errorStrings, err.Error())
+		}
+		return nil, fmt.Errorf("encountered %d errors: %s", len(errorStrings), strings.Join(errorStrings, "; "))
+	}
+
+	return summaries, nil
+}
+
+// GetLastSummaryID retrieves the ID of the last available summary
+// by checking the total field from the /summary endpoint
+func (c *Client) GetLastSummaryID() (int, error) {
+	summaryURL := c.config.GetSummaryURL()
+
+	resp, err := c.httpClient.Get(summaryURL)
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve summary: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var response Response
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return response.Total, nil
+}
+
+// GetLastSummaryID retrieves the ID of the last available summary using defaults
+// Kept for backward compatibility
+func GetLastSummaryID() (int, error) {
+	client := NewDefaultClient()
+	return client.GetLastSummaryID()
+}

--- a/finowl-ai-assistant/feedstock/client_test.go
+++ b/finowl-ai-assistant/feedstock/client_test.go
@@ -1,0 +1,204 @@
+package feedstock_test
+
+import (
+	"finowl-ai-assistant/feedstock"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestGetSummary(t *testing.T) {
+	// Setup mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check request path and method
+		if r.URL.Path != "/summary" {
+			t.Errorf("Expected request to '/summary', got '%s'", r.URL.Path)
+		}
+
+		// Check for expected query parameters
+		id := r.URL.Query().Get("id")
+		if id != "123" {
+			t.Errorf("Expected id=123, got id=%s", id)
+		}
+
+		// Return mock response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"summary": {
+				"id": 123,
+				"timestamp": "2023-05-15T14:30:00Z",
+				"content": "Bitcoin reached a new all-time high today."
+			},
+			"total": 1
+		}`))
+	}))
+	defer server.Close()
+
+	// Create client with the mock server URL
+	client := feedstock.NewClient(server.URL)
+
+	// Call the method being tested
+	summary, err := client.GetSummary(123)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Check each field is populated correctly
+	if summary.ID != 123 {
+		t.Errorf("Expected ID 123, got %d", summary.ID)
+	}
+
+	expectedTime, _ := time.Parse(time.RFC3339, "2023-05-15T14:30:00Z")
+	if !summary.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, summary.Timestamp)
+	}
+
+	expectedContent := "Bitcoin reached a new all-time high today."
+	if summary.Content != expectedContent {
+		t.Errorf("Expected content '%s', got '%s'", expectedContent, summary.Content)
+	}
+}
+
+func TestFetchSummaries(t *testing.T) {
+	// Track requested IDs to verify all were requested
+	requestedIDs := make(map[int]bool)
+
+	// Setup mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Extract ID from query parameters
+		idStr := r.URL.Query().Get("id")
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			t.Errorf("Invalid ID parameter: %s", idStr)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Record that this ID was requested
+		requestedIDs[id] = true
+
+		// Return different mock responses based on the ID
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Create a response with the ID embedded in the content
+		response := fmt.Sprintf(`{
+			"summary": {
+				"id": %d,
+				"timestamp": "2023-05-15T14:30:00Z",
+				"content": "Summary content for ID %d"
+			},
+			"total": 1
+		}`, id, id)
+
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	// Create client with the mock server URL
+	client := feedstock.NewClient(server.URL)
+
+	// Define test parameters
+	startID := 200
+	count := 5
+
+	// Call the method being tested
+	summaries, err := client.FetchSummaries(startID, count)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Check we got the expected number of summaries
+	if len(summaries) != count {
+		t.Errorf("Expected %d summaries, got %d", count, len(summaries))
+	}
+
+	// Check each expected ID was requested
+	for i := 0; i < count; i++ {
+		id := startID - i
+		if !requestedIDs[id] {
+			t.Errorf("ID %d was not requested", id)
+		}
+	}
+
+	// Create a map for easier lookup
+	summaryMap := make(map[int]feedstock.Summary)
+	for _, summary := range summaries {
+		summaryMap[summary.ID] = summary
+	}
+
+	// Check each summary has the correct data
+	for i := 0; i < count; i++ {
+		id := startID - i
+
+		summary, exists := summaryMap[id]
+		if !exists {
+			t.Errorf("Summary with ID %d not found in results", id)
+			continue
+		}
+
+		// Check ID
+		if summary.ID != id {
+			t.Errorf("Expected ID %d, got %d", id, summary.ID)
+		}
+
+		// Check timestamp
+		expectedTime, _ := time.Parse(time.RFC3339, "2023-05-15T14:30:00Z")
+		if !summary.Timestamp.Equal(expectedTime) {
+			t.Errorf("For ID %d: Expected timestamp %v, got %v", id, expectedTime, summary.Timestamp)
+		}
+
+		// Check content
+		expectedContent := fmt.Sprintf("Summary content for ID %d", id)
+		if summary.Content != expectedContent {
+			t.Errorf("For ID %d: Expected content '%s', got '%s'", id, expectedContent, summary.Content)
+		}
+	}
+}
+
+func TestGetLastSummaryID(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check request path
+		if r.URL.Path != "/summary" {
+			t.Errorf("Expected request to '/summary', got '%s'", r.URL.Path)
+		}
+
+		// Return mock response with total field set to 500
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"summary": {
+				"id": 500,
+				"timestamp": "2023-05-15T14:30:00Z",
+				"content": "Latest summary content"
+			},
+			"total": 500
+		}`))
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server URL
+	client := feedstock.NewClient(server.URL)
+
+	// Call the client method being tested
+	lastID, err := client.GetLastSummaryID()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Check the returned ID matches the expected value
+	expectedID := 500
+	if lastID != expectedID {
+		t.Errorf("Expected last summary ID to be %d, got %d", expectedID, lastID)
+	}
+
+	// Note: Testing the global function GetLastSummaryID() would require
+	// changing environment variables or mocking the HTTP client, which is
+	// beyond the scope of this test. The client.GetLastSummaryID() method
+	// is effectively the same implementation.
+}

--- a/finowl-ai-assistant/feedstock/models.go
+++ b/finowl-ai-assistant/feedstock/models.go
@@ -1,0 +1,16 @@
+package feedstock
+
+import "time"
+
+// Summary represents the structure of the Finowl API response
+type Summary struct {
+	ID        int       `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+	Content   string    `json:"content"`
+}
+
+// Response represents the full API response
+type Response struct {
+	Summary Summary `json:"summary"`
+	Total   int     `json:"total"`
+}


### PR DESCRIPTION
- Implement the  package to fetch AI training data from the FinOwl API
- Supports single and concurrent summary fetching
- Includes helper to get latest summary ID from /summary
- Added unit tests with mocked HTTP responses