### PR TITLE
refactor(ai): support multi-turn chat via GetChatCompletion in AIClient interface

### DIFF
--- a/finowl-ai-assistant/internal/handlers/ai_analyzer_test.go
+++ b/finowl-ai-assistant/internal/handlers/ai_analyzer_test.go
@@ -21,6 +21,11 @@ func (m *mockAIClient) GetCompletion(prompt string, model string, temperature fl
 	return "# Mocked AI Response\n\nMarket is volatile today with BTC leading gains.", nil
 }
 
+// GetChatCompletion returns a mock assistant reply using message history
+func (m *mockAIClient) GetChatCompletion(messages []ai.ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+	return "Sure, let's dive into your question based on the latest market summaries.", nil
+}
+
 func TestAIAnalyzer_Success(t *testing.T) {
 	// Create a mock AI client that returns a fixed markdown response
 	mockClient := &mockAIClient{}

--- a/finowl-ai-assistant/pkg/ai/analyzer.go
+++ b/finowl-ai-assistant/pkg/ai/analyzer.go
@@ -42,6 +42,7 @@ type MarketAnalysisResponse struct {
 // AIClient defines the expected interface for interacting with AI models
 type AIClient interface {
 	GetCompletion(prompt string, model string, temperature float32, maxTokens int) (string, error)
+	GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error)
 }
 
 // MarketAnalyzer is the core engine for analyzing feedstock summaries via AI

--- a/finowl-ai-assistant/pkg/ai/analyzer_test.go
+++ b/finowl-ai-assistant/pkg/ai/analyzer_test.go
@@ -16,6 +16,11 @@ func (m *MockClientWithErrorResponse) GetCompletion(prompt string, model string,
 	return "**Error:** simulated AI error", nil
 }
 
+// Satisfy interface (chat mode not tested in this case)
+func (m *MockClientWithErrorResponse) GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+	return "**Error:** simulated AI error (chat)", nil
+}
+
 // TestMarketAnalyzer tests the market analyzer functionality
 func TestMarketAnalyzer(t *testing.T) {
 	mockClient := NewMockClient()

--- a/finowl-ai-assistant/pkg/ai/mock.go
+++ b/finowl-ai-assistant/pkg/ai/mock.go
@@ -15,6 +15,16 @@ func NewMockClient() *MockClient {
 	return &MockClient{}
 }
 
+// GetChatCompletion returns a mock assistant reply for chat-based interaction
+func (c *MockClient) GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+	fmt.Println("Using mock AI chat client")
+	for i, msg := range messages {
+		fmt.Printf("[%d] %s: %s\n", i, msg.Role, msg.Content)
+	}
+
+	return "Sure! Based on the market context, I'm ready to answer your questions.", nil
+}
+
 // GetCompletion returns a mock response for testing
 func (c *MockClient) GetCompletion(prompt string, model string, temperature float32, maxTokens int) (string, error) {
 	fmt.Println("Using mock AI client")

--- a/finowl-ai-assistant/pkg/ai/types.go
+++ b/finowl-ai-assistant/pkg/ai/types.go
@@ -1,0 +1,6 @@
+package ai
+
+type ChatMessage struct {
+	Role    string `json:"role"`    // "user" or "assistant"
+	Content string `json:"content"` // actual message
+}


### PR DESCRIPTION

- Added ChatMessage struct to represent role-based chat messages
- Extended AIClient interface with GetChatCompletion([]ChatMessage, ...)
- Updated client.go to implement GetChatCompletion with OpenAI-compatible payload