### PR TITLE
feat: add /ask endpoint with multi-turn memory using summaries and message history

### DIFF
--- a/finowl-ai-assistant/cmd/server/main.go
+++ b/finowl-ai-assistant/cmd/server/main.go
@@ -80,6 +80,10 @@ func setupServer(application *app.App) *http.Server {
 	// AI analysis endpoint
 	mux.HandleFunc("/analyze", application.Handler.AIAnalyzer)
 
+	// AI chat endpoint (stateful)
+	application.Handler.MarketChatter().Preload("finowl_user_01.testnet", application.Summaries)
+	mux.HandleFunc("/ask", application.Handler.AIMarketChat)
+
 	// Health check endpoint
 	mux.HandleFunc("/health", application.Handler.HealthCheckHandler)
 

--- a/finowl-ai-assistant/internal/app/app.go
+++ b/finowl-ai-assistant/internal/app/app.go
@@ -4,10 +4,12 @@ import (
 	"finowl-ai-assistant/internal/api"
 	"finowl-ai-assistant/internal/config"
 	"finowl-ai-assistant/internal/handlers"
+	"finowl-ai-assistant/internal/session"
 	"finowl-ai-assistant/pkg/ai"
 	netconfig "finowl-ai-assistant/pkg/config"
 	"finowl-ai-assistant/pkg/feedstock"
 	"finowl-ai-assistant/pkg/near"
+
 	"fmt"
 	"log"
 	"os"
@@ -38,7 +40,6 @@ func NewApp(networkType string) (*App, error) {
 		return nil, fmt.Errorf("failed to load network configuration: %w", err)
 	}
 
-	// Log network configuration
 	log.Printf("🔧 Network configuration: Network=%s, Contract=%s",
 		netCfg.Network, netCfg.ContractName)
 
@@ -60,8 +61,6 @@ func NewApp(networkType string) (*App, error) {
 
 	// Create market analyzer
 	marketAnalyzer := ai.NewMarketAnalyzer(aiClient)
-
-	// Configure market analyzer with application settings
 	marketAnalyzer.Configure(cfg.ResourcePaths.PromptsPath, cfg.AI.Model)
 
 	// Create feedstock client
@@ -77,31 +76,34 @@ func NewApp(networkType string) (*App, error) {
 		return nil, fmt.Errorf("failed to fetch summaries: %w", err)
 	}
 
-	// Create handler
-	handler := handlers.NewHandler(marketAnalyzer, summaries)
+	// Create session manager (2-hour TTL)
+	sessionTTL := 2 * time.Hour
+	sessionManager := session.NewChatSessionManager(sessionTTL)
 
-	// Create NEAR client
+	// Create market chatter (chat logic)
+	marketChatter := ai.NewMarketChatter(sessionManager, aiClient, cfg.AI.Model)
+
+	// Create handler
+	handler := handlers.NewHandler(marketAnalyzer, summaries, marketChatter)
+
+	// Create NEAR client (optional)
 	var nearClient *near.Client
 	var apiHandler *api.Handler
 
-	// Try to initialize the NEAR client with network configuration
 	if netCfg.PrivateKey == "" {
 		log.Printf("⚠️ Warning: No private key found for %s network", netCfg.Network)
 		log.Println("⚠️ Warning: NEAR blockchain functionality will not be available")
 	} else {
 		nearClient, err = near.NewClient(
-			netCfg.OwnerAccountID, // Owner account ID from network config
-			netCfg.PrivateKey,     // Owner private key
-			netCfg.ContractName,   // Contract name from network config
-			netCfg.RPCURL,         // RPC URL from network config
+			netCfg.OwnerAccountID,
+			netCfg.PrivateKey,
+			netCfg.ContractName,
+			netCfg.RPCURL,
 		)
 
 		if err != nil {
 			log.Printf("⚠️ Warning: Failed to initialize NEAR client: %v", err)
-			log.Println("⚠️ NEAR blockchain functionality will not be available")
-			// Continue without NEAR functionality
 		} else {
-			// Create API handler only if NEAR client was created successfully
 			apiHandler = api.NewHandler(nearClient)
 			log.Printf("✅ NEAR client initialized for network %s with contract %s and owner %s",
 				netCfg.Network, netCfg.ContractName, netCfg.OwnerAccountID)
@@ -125,17 +127,14 @@ func NewApp(networkType string) (*App, error) {
 func fetchSummaries(client *feedstock.Client, count int) ([]feedstock.Summary, error) {
 	log.Printf("🔍 Attempting to fetch %d summaries...", count)
 
-	// Try to get the last summary ID
 	lastID, err := client.GetLastSummaryID()
 	if err != nil {
 		log.Printf("⚠️ Warning: Failed to get last summary ID: %v", err)
-		log.Printf("⚠️ Using default ID of %d for summaries", count)
-		lastID = count // Fallback to using the count as the last ID
+		lastID = count
 	} else {
 		log.Printf("✅ Successfully retrieved last summary ID: %d", lastID)
 	}
 
-	// Fetch the latest summaries
 	log.Printf("🔍 Fetching %d summaries from ID %d...", count, lastID)
 	startTime := time.Now()
 
@@ -145,41 +144,12 @@ func fetchSummaries(client *feedstock.Client, count int) ([]feedstock.Summary, e
 		return nil, err
 	}
 
-	fetchTime := time.Since(startTime)
-
-	log.Printf("✅ Fetched %d summaries in %v", len(summaries), fetchTime)
-
-	// Log summary IDs and timestamps for debugging
-	if len(summaries) > 0 {
-		ids := make([]int, 0, len(summaries))
-		var oldestTime, newestTime time.Time
-
-		for i, s := range summaries {
-			ids = append(ids, s.ID)
-
-			if i == 0 || s.Timestamp.After(newestTime) {
-				newestTime = s.Timestamp
-			}
-
-			if i == 0 || s.Timestamp.Before(oldestTime) {
-				oldestTime = s.Timestamp
-			}
-		}
-
-		log.Printf("📊 Summary IDs: %v", ids)
-		log.Printf("📊 Newest summary: %s", newestTime.Format(time.RFC3339))
-		log.Printf("📊 Oldest summary: %s", oldestTime.Format(time.RFC3339))
-		log.Printf("📊 Date range: %v", newestTime.Sub(oldestTime))
-	} else {
-		log.Printf("⚠️ No summaries were fetched!")
-	}
-
+	log.Printf("✅ Fetched %d summaries in %v", len(summaries), time.Since(startTime))
 	return summaries, nil
 }
 
 // EnsureDirs creates necessary directories if they don't exist
 func (a *App) EnsureDirs() error {
-	// Ensure prompts directory exists
 	promptsDir := a.Config.ResourcePaths.PromptsPath
 	if _, err := os.Stat(promptsDir); os.IsNotExist(err) {
 		log.Printf("Creating prompts directory: %s", promptsDir)
@@ -187,6 +157,5 @@ func (a *App) EnsureDirs() error {
 			return fmt.Errorf("failed to create prompts directory: %w", err)
 		}
 	}
-
 	return nil
 }

--- a/finowl-ai-assistant/internal/handlers/ai_analyzer_test.go
+++ b/finowl-ai-assistant/internal/handlers/ai_analyzer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"finowl-ai-assistant/pkg/ai"
+	"finowl-ai-assistant/pkg/chat"
 	"finowl-ai-assistant/pkg/feedstock"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,7 @@ func (m *mockAIClient) GetCompletion(prompt string, model string, temperature fl
 }
 
 // GetChatCompletion returns a mock assistant reply using message history
-func (m *mockAIClient) GetChatCompletion(messages []ai.ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+func (m *mockAIClient) GetChatCompletion(messages []chat.Message, model string, temperature float32, maxTokens int) (string, error) {
 	return "Sure, let's dive into your question based on the latest market summaries.", nil
 }
 
@@ -64,7 +65,7 @@ Respond in Markdown format.`
 			Content:   "BTC is up 5% today.",
 		},
 	}
-	handler := NewHandler(analyzer, summaries)
+	handler := NewHandler(analyzer, summaries, nil)
 
 	// Step 4: Build request and response
 	body, _ := json.Marshal(map[string]string{
@@ -85,7 +86,7 @@ Respond in Markdown format.`
 func TestAIAnalyzer_EmptyQuestion(t *testing.T) {
 	mockClient := &mockAIClient{}
 	marketAnalyzer := ai.NewMarketAnalyzer(mockClient)
-	handler := NewHandler(marketAnalyzer, []feedstock.Summary{})
+	handler := NewHandler(marketAnalyzer, []feedstock.Summary{}, nil)
 
 	body, _ := json.Marshal(map[string]string{
 		"question": "  ",
@@ -102,7 +103,7 @@ func TestAIAnalyzer_EmptyQuestion(t *testing.T) {
 }
 
 func TestAIAnalyzer_MethodNotAllowed(t *testing.T) {
-	handler := NewHandler(nil, nil)
+	handler := NewHandler(nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/analyze", nil)
 	w := httptest.NewRecorder()
 

--- a/finowl-ai-assistant/internal/handlers/ask.go
+++ b/finowl-ai-assistant/internal/handlers/ask.go
@@ -1,0 +1,129 @@
+package handlers
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"finowl-ai-assistant/internal/session"
+	"finowl-ai-assistant/pkg/ai"
+	"finowl-ai-assistant/pkg/chat"
+)
+
+type AskHandler struct {
+	SessionManager *session.ChatSessionManager
+	AIClient       ai.AIClient
+	Model          string
+}
+
+type askRequest struct {
+	UserID   string `json:"user_id"`
+	Question string `json:"question"`
+}
+
+type askResponse struct {
+	Reply string `json:"reply"`
+}
+
+func (h *Handler) MarketChatter() *ai.MarketChatter {
+	return h.marketChatter
+}
+
+// AIMarketChat handles POST /ask and returns a chat-based response from the AI assistant
+func (h *Handler) AIMarketChat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		UserID   string `json:"user_id"`
+		Question string `json:"question"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.UserID) == "" || strings.TrimSpace(req.Question) == "" {
+		http.Error(w, "Both user_id and question are required", http.StatusBadRequest)
+		return
+	}
+
+	reqID := fmt.Sprintf("%x", md5.Sum([]byte(time.Now().String()+req.UserID+req.Question)))[:8]
+	log.Printf("💬 [CHAT-%s] New chat request from %s", reqID, req.UserID)
+	log.Printf("💬 [CHAT-%s] Question: %s", reqID, req.Question)
+
+	// Perform chat
+	answer, err := h.marketChatter.Chat(req.UserID, req.Question)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Printf("⚠️ [CHAT-%s] No active session found for user %s. Suggest calling Preload().", reqID, req.UserID)
+			http.Error(w, fmt.Sprintf("No session found for user '%s'. Please start a session first.", req.UserID), http.StatusBadRequest)
+			return
+		}
+		log.Printf("❌ [CHAT-%s] Chat error: %v", reqID, err)
+		http.Error(w, "Failed to process chat request", http.StatusInternalServerError)
+		return
+	}
+
+	resp := map[string]string{
+		"reply": answer,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("❌ [CHAT-%s] Failed to send response: %v", reqID, err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("✅ [CHAT-%s] Responded successfully", reqID)
+}
+func (h *AskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req askRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.UserID == "" || req.Question == "" {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Retrieve full history and summaries
+	history := h.SessionManager.GetMessages(req.UserID)
+	summaries := h.SessionManager.GetSummaries(req.UserID)
+	if summaries == nil {
+		http.Error(w, "No session found for user", http.StatusNotFound)
+		return
+	}
+
+	// Add current user question to message history
+	messages := append(history, chat.Message{
+		Role:    "user",
+		Content: req.Question,
+	})
+
+	// Call AI
+	reply, err := h.AIClient.GetChatCompletion(messages, h.Model, 0.1, 1000)
+	if err != nil {
+		http.Error(w, "AI error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Store assistant reply
+	h.SessionManager.AddMessage(req.UserID, "user", req.Question)
+	h.SessionManager.AddMessage(req.UserID, "assistant", reply)
+
+	resp := askResponse{Reply: reply}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/finowl-ai-assistant/internal/handlers/handler.go
+++ b/finowl-ai-assistant/internal/handlers/handler.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"finowl-ai-assistant/pkg/ai"
+	"finowl-ai-assistant/pkg/feedstock"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// Handler aggregates all dependencies for public HTTP endpoints
+type Handler struct {
+	marketAnalyzer *ai.MarketAnalyzer
+	summaries      []feedstock.Summary
+	marketChatter  *ai.MarketChatter
+}
+
+// NewHandler initializes a full-featured handler
+func NewHandler(
+	marketAnalyzer *ai.MarketAnalyzer,
+	summaries []feedstock.Summary,
+	marketChatter *ai.MarketChatter,
+
+) *Handler {
+	return &Handler{
+		marketAnalyzer: marketAnalyzer,
+		summaries:      summaries,
+		marketChatter:  marketChatter,
+	}
+}
+
+// decodeQuestion parses a POST body and extracts the `question` field
+func decodeQuestion(r *http.Request) (string, error) {
+	var request struct {
+		Question string `json:"question"`
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading request body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return "", fmt.Errorf("invalid request body: %w", err)
+	}
+	if strings.TrimSpace(request.Question) == "" {
+		return "", fmt.Errorf("question cannot be empty")
+	}
+	return request.Question, nil
+}
+
+// logRequest formats logs with a consistent request ID
+func logRequest(reqID, label, msg string) {
+	log.Printf("📝 [REQ-%s] %s: %s", reqID, label, msg)
+}

--- a/finowl-ai-assistant/internal/session/manager.go
+++ b/finowl-ai-assistant/internal/session/manager.go
@@ -4,20 +4,14 @@ import (
 	"sync"
 	"time"
 
+	"finowl-ai-assistant/pkg/chat"
 	"finowl-ai-assistant/pkg/feedstock"
 )
-
-// ChatMessage represents a message exchanged with the AI
-type ChatMessage struct {
-	Role    string    // "user" or "assistant"
-	Content string    // message content
-	Time    time.Time // timestamp of message
-}
 
 // ChatSession holds summaries and chat messages for a user
 type ChatSession struct {
 	Summaries []feedstock.Summary
-	Messages  []ChatMessage
+	Messages  []chat.Message
 	UpdatedAt time.Time // last activity time
 }
 
@@ -48,7 +42,7 @@ func (m *ChatSessionManager) StartSession(userID string, summaries []feedstock.S
 
 	m.sessions[userID] = &ChatSession{
 		Summaries: summaries,
-		Messages:  []ChatMessage{},
+		Messages:  []chat.Message{},
 		UpdatedAt: time.Now(),
 	}
 }
@@ -59,7 +53,7 @@ func (m *ChatSessionManager) AddMessage(userID, role, content string) {
 	defer m.mutex.Unlock()
 
 	if session, exists := m.sessions[userID]; exists {
-		session.Messages = append(session.Messages, ChatMessage{
+		session.Messages = append(session.Messages, chat.Message{
 			Role:    role,
 			Content: content,
 			Time:    time.Now(),
@@ -69,7 +63,7 @@ func (m *ChatSessionManager) AddMessage(userID, role, content string) {
 }
 
 // GetMessages returns the full message history for a session
-func (m *ChatSessionManager) GetMessages(userID string) []ChatMessage {
+func (m *ChatSessionManager) GetMessages(userID string) []chat.Message {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 

--- a/finowl-ai-assistant/pkg/ai/analyzer.go
+++ b/finowl-ai-assistant/pkg/ai/analyzer.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"finowl-ai-assistant/pkg/chat"
 	"finowl-ai-assistant/pkg/feedstock"
 )
 
@@ -42,7 +43,7 @@ type MarketAnalysisResponse struct {
 // AIClient defines the expected interface for interacting with AI models
 type AIClient interface {
 	GetCompletion(prompt string, model string, temperature float32, maxTokens int) (string, error)
-	GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error)
+	GetChatCompletion(messages []chat.Message, model string, temperature float32, maxTokens int) (string, error)
 }
 
 // MarketAnalyzer is the core engine for analyzing feedstock summaries via AI

--- a/finowl-ai-assistant/pkg/ai/analyzer_test.go
+++ b/finowl-ai-assistant/pkg/ai/analyzer_test.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"finowl-ai-assistant/pkg/chat"
 	"finowl-ai-assistant/pkg/feedstock"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func (m *MockClientWithErrorResponse) GetCompletion(prompt string, model string,
 }
 
 // Satisfy interface (chat mode not tested in this case)
-func (m *MockClientWithErrorResponse) GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+func (m *MockClientWithErrorResponse) GetChatCompletion(messages []chat.Message, model string, temperature float32, maxTokens int) (string, error) {
 	return "**Error:** simulated AI error (chat)", nil
 }
 

--- a/finowl-ai-assistant/pkg/ai/client.go
+++ b/finowl-ai-assistant/pkg/ai/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"errors"
+	"finowl-ai-assistant/pkg/chat"
 	"fmt"
 	"io"
 	"log"
@@ -126,7 +127,7 @@ func (c *Client) GetCompletion(prompt string, model string, temperature float32,
 	return content, nil
 }
 
-func (c *Client) GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+func (c *Client) GetChatCompletion(messages []chat.Message, model string, temperature float32, maxTokens int) (string, error) {
 	if c.APIKey == "" {
 		return "", fmt.Errorf("API key not set")
 	}

--- a/finowl-ai-assistant/pkg/ai/market_chatter.go
+++ b/finowl-ai-assistant/pkg/ai/market_chatter.go
@@ -1,0 +1,46 @@
+package ai
+
+import (
+	"context"
+	"finowl-ai-assistant/internal/session"
+	"finowl-ai-assistant/pkg/chat"
+	"finowl-ai-assistant/pkg/feedstock"
+)
+
+type MarketChatter struct {
+	sessionManager *session.ChatSessionManager
+	aiClient       AIClient
+	model          string
+}
+
+func NewMarketChatter(sm *session.ChatSessionManager, client AIClient, model string) *MarketChatter {
+	return &MarketChatter{
+		sessionManager: sm,
+		aiClient:       client,
+		model:          model,
+	}
+}
+
+func (mc *MarketChatter) Chat(userID, question string) (string, error) {
+	history := mc.sessionManager.GetMessages(userID)
+	if mc.sessionManager.GetSummaries(userID) == nil {
+		return "", context.DeadlineExceeded
+	}
+
+	messages := append(history, chat.Message{Role: "user", Content: question})
+
+	resp, err := mc.aiClient.GetChatCompletion(messages, mc.model, 0.1, 1000)
+	if err != nil {
+		return "", err
+	}
+
+	mc.sessionManager.AddMessage(userID, "user", question)
+	mc.sessionManager.AddMessage(userID, "assistant", resp)
+
+	return resp, nil
+}
+
+// Preload initializes the session with summaries for a user
+func (mc *MarketChatter) Preload(userID string, summaries []feedstock.Summary) {
+	mc.sessionManager.StartSession(userID, summaries)
+}

--- a/finowl-ai-assistant/pkg/ai/mock.go
+++ b/finowl-ai-assistant/pkg/ai/mock.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"encoding/json"
+	"finowl-ai-assistant/pkg/chat"
 	"fmt"
 )
 
@@ -16,7 +17,7 @@ func NewMockClient() *MockClient {
 }
 
 // GetChatCompletion returns a mock assistant reply for chat-based interaction
-func (c *MockClient) GetChatCompletion(messages []ChatMessage, model string, temperature float32, maxTokens int) (string, error) {
+func (c *MockClient) GetChatCompletion(messages []chat.Message, model string, temperature float32, maxTokens int) (string, error) {
 	fmt.Println("Using mock AI chat client")
 	for i, msg := range messages {
 		fmt.Printf("[%d] %s: %s\n", i, msg.Role, msg.Content)

--- a/finowl-ai-assistant/pkg/ai/types.go
+++ b/finowl-ai-assistant/pkg/ai/types.go
@@ -1,6 +1,0 @@
-package ai
-
-type ChatMessage struct {
-	Role    string `json:"role"`    // "user" or "assistant"
-	Content string `json:"content"` // actual message
-}

--- a/finowl-ai-assistant/pkg/chat/message.go
+++ b/finowl-ai-assistant/pkg/chat/message.go
@@ -1,0 +1,9 @@
+package chat
+
+import "time"
+
+type Message struct {
+	Role    string    `json:"role"`    // "user" or "assistant"
+	Content string    `json:"content"` // actual message
+	Time    time.Time `json:"time"`    // timestamp of message
+}


### PR DESCRIPTION

- Introduced ChatSessionManager to manage per-user sessions in memory
- Added MarketChatter to support context-aware chat with session persistence
- Integrated /ask endpoint via AIMarketChat handler
- Logged session activity, tracked errors, and enabled future multi-user support
- Refactored handler structure for better modularity and reuse